### PR TITLE
Pass limitOPtion to add limit functionality

### DIFF
--- a/Chirp.CLI/Program.cs
+++ b/Chirp.CLI/Program.cs
@@ -16,24 +16,32 @@ class Program
 
 
         string path = "../src/chirp_cli_db.csv"; //Path to CSV file 
+
+        //the rootCommand is "dotnet run"
         var rootCommand = new RootCommand();
+
+        // by making a new Command, we create a subCommand to the rootCommand, namingly "read"
         var readCommand = new Command("read", "Displays cheeps");
 
-        var limitOption = new Option<int>
+        // by making a new Option, we create anoption to the subCommand, namingly "--limit"
+        // Which gives an integer to our data_access.Read(), so that we limit the amount of cheeps displayed
+        var limitOption = new Option<int?> //"int?" makes the interger nullable
             (name: "--limit",
             description: "limits the number of cheeps to be displayed",
-            getDefaultValue: () => 30);
+            getDefaultValue: () => null );
 
 
-
+        //we add the readCommand to the rootCommand, to engage with readCommand type "dotnet run read" in the terminal
         rootCommand.Add(readCommand);
+        //We add the limitOption to the readCommand, to engage with limitOption type "dotnet run read --limit <int>" in the terminal
         readCommand.Add(limitOption);
 
+        // gets the commands from the commandline and exectutes the following code
         readCommand.SetHandler((limitOption) =>
         {
             //CSV Read part from: https://joshclose.github.io/CsvHelper/getting-started/
             IDatabaseRepository<Cheep> data_access = new CSVDatabase<Cheep>("../src/chirp_cli_db.csv");
-            IEnumerable<Cheep> records = data_access.Read();
+            IEnumerable<Cheep> records = data_access.Read(limitOption);
 
             foreach (Cheep cheep in records)
             {


### PR DESCRIPTION
Passing the limitOPtion to data_access, gives the functionality of limiting the amount of read cheeps. As well as adding som comments.

Co-authored-by: Lukas: <lupa@itu.dk>