### PR TITLE
ChripCSVDBService handles the limit of cheeps read

### DIFF
--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -63,48 +63,36 @@ public class Program
         // gets the commands from the commandline and exectutes the following code
         readCommand.SetHandler(async (limitOptionValue) =>
         {
-            if (limitOptionValue < 0)
-            {
-                System.Console.WriteLine("the --limit option should be greater than or equal to 0");
-                return;
-            }
+            // if (limitOptionValue < 0)
+            // {
+            //     System.Console.WriteLine("the --limit option should be greater than or equal to 0");
+            //     return;
+            // }
             
-            // IEnumerable<Cheep> records = data_access.Read(limitOptionValue);
-            
-            //The records are passed to the UserInterface, which handles how the records are presented to the user
-            List<Cheep> all_records;
-            List<Cheep> relevant_records = new List<Cheep>();
+            List<Cheep> records;
             string baseURL = "http://localhost:5089/";
+            string uri = $"cheeps?limit={limitOptionValue}";
+
             using HttpClient client = new();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             client.BaseAddress = new Uri(baseURL);
 
-            HttpResponseMessage response = await client.GetAsync("cheeps"); 
+            var response = await client.GetAsync(uri); 
 
             if (response.IsSuccessStatusCode)//response.IsSuccessStatusCode From GPT
             {
                 // The HTTP request was successful
-                all_records = await response.Content.ReadFromJsonAsync<List<Cheep>>();
-                
-                if (limitOptionValue != null && limitOptionValue < all_records.Count)
-                {
-                    for (int i = all_records.Count - 1; i >= all_records.Count - limitOptionValue; i--)
-                    {
-                        relevant_records.Add(all_records[i]);
-                    }
-                }
-                else
-                {
-                    relevant_records = all_records;
-                }
-
-                UserInterface.PrintCheeps(relevant_records);
+                records = await response.Content.ReadFromJsonAsync<List<Cheep>>();
+                //The records are passed to the UserInterface, which handles how the records are presented to the user
+                UserInterface.PrintCheeps(records);
             }
             else
             {
                 // Handle the case when the HTTP request was not successful - From GPT
+                string errorMessage = await response.Content.ReadAsStringAsync();
                 System.Console.WriteLine($"HTTP request failed with status code: {response.StatusCode}");
+                System.Console.WriteLine($"Error Message: {errorMessage}");
             }
         }, limitOption);
 

--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -63,12 +63,6 @@ public class Program
         // gets the commands from the commandline and exectutes the following code
         readCommand.SetHandler(async (limitOptionValue) =>
         {
-            // if (limitOptionValue < 0)
-            // {
-            //     System.Console.WriteLine("the --limit option should be greater than or equal to 0");
-            //     return;
-            // }
-            
             List<Cheep> records;
             string baseURL = "http://localhost:5089/";
             string uri = $"cheeps?limit={limitOptionValue}";

--- a/test/Chirp.CSVDBService.Tests/UnitTest1.cs
+++ b/test/Chirp.CSVDBService.Tests/UnitTest1.cs
@@ -8,9 +8,6 @@ public class UnitTest1
     public void Test_HTTP_resssponeMsg_if_limit_is_set_to_1()
     {
         //Arange
-        public record Cheep(string Author , string Message , long Timestamp);
-        //Act
-        List<Cheep> responsList = Read(1);
         //Assert
         
     }


### PR DESCRIPTION
The functionallity of the limit was before in Chirp.CLI.Client But is now in ChirpCSVDBService. The Read methode is responsable for limiting the amount of cheeps returned fro the http get call. The http call is now sending success or fail responses back, which is then displayed to the user.