### PR TITLE
Fixed read

### DIFF
--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -74,8 +74,13 @@ public class Program
         {
             List<Cheep> records;
             string baseURL = "http://localhost:5089/";
-            string uri = $"cheeps?limit={limitOptionValue}";
-
+            string uri;
+            if( limitOptionValue.ToString() == ""){
+                uri = $"cheeps";
+            } else {
+                uri = $"cheeps?limit={limitOptionValue}";
+            }
+            
             using HttpClient client = new();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/Chirp.CSVDBService/Program.cs
+++ b/src/Chirp.CSVDBService/Program.cs
@@ -11,11 +11,29 @@ using System.ComponentModel.Design;
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-app.MapGet("/cheeps" , (int? limit) =>            
+app.MapGet("/cheeps" , (int? limit) => 
             {           
                 List<Cheep> response;                 //From https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-7.0 
                 try{                                  //Section: IResult return values
                     response = Read(limit);           // Try-catch: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/exception-handling-statements
+                } 
+                catch (ArgumentOutOfRangeException e){ 
+                    return Results.BadRequest(e.Message); // this line is from GPT
+                } 
+                catch (FileNotFoundException e){ 
+                    return Results.NotFound(e.Message);
+                }
+                //The response is a list of Cheeps
+                return Results.Ok(response);
+            })
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
+app.MapGet("/cheeps", () => 
+            {        
+                List<Cheep> response;                 //From https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-7.0 
+                try{                                  //Section: IResult return values
+                    response = Read(null);           // Try-catch: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/exception-handling-statements
                 } 
                 catch (ArgumentOutOfRangeException e){ 
                     return Results.BadRequest(e.Message); // this line is from GPT

--- a/src/Chirp.CSVDBService/chirp_cli_db.csv
+++ b/src/Chirp.CSVDBService/chirp_cli_db.csv
@@ -1,0 +1,3 @@
+Author,Message,Timestamp
+
+Admin,"Welcome to a clean, empty Chirp-Server",1695906600


### PR DESCRIPTION
When the limit is set to null, it cannot be given as an argument to the http call, since is send as "" and that is not compatiable with int?, which takes int or null.

wiWill change this when we are limiting the read to 32 cheeps as default